### PR TITLE
added a plugin-descriptor

### DIFF
--- a/plugin-descriptor.properties
+++ b/plugin-descriptor.properties
@@ -1,0 +1,4 @@
+description=elastic-workbook - todo
+version=1.0.0
+site=true
+name=elastic-workbook


### PR DESCRIPTION
Appears to be necessary to instal workbook on either ES 2.0 or ES 2.1  Otherwise I was getting this error.

```
ERROR: Could not find plugin descriptor 'plugin-descriptor.properties' in plugin zip
ERROR: Service 'elasticnode' failed to build: The command '/bin/sh -c /opt/elasticsearch/bin/plugin install derickson/elastic-workbook' returned a non-zero code: 70
```
